### PR TITLE
Add plot of time-dependent diffusion at different timepoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,8 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python,macos,visualstudiocode,pycharm
 
+*.png
+*.jpeg
+*.mp4
+*.gif
+*.mov

--- a/src/scientific_computing/time_dependent_diffusion/__init__.py
+++ b/src/scientific_computing/time_dependent_diffusion/__init__.py
@@ -1,0 +1,6 @@
+from .utils.time_dependent_diffusion import (
+    one_step_diffusion as one_step_diffusion,
+)
+from .utils.time_dependent_diffusion import (
+    time_dependent_diffusion as time_dependent_diffusion,
+)


### PR DESCRIPTION
Closes #7. Relates to question 2.F in the assignment, plots the state of diffusion at each timepoint in a specified list.

The plot is generated via the CLI, and the associated command lives under the `td-diffusion` subcommand ('td' == "time-dependent"). 

If the supplied values of `dt`, `dx`, and `diffusivity` are such that the stability condition does not hold, a confirmation prompt is presented to alert the user as such.

Example usage:

```zsh
# Each "-m" specifies a single timestep at which to record the state.
 uv run scicomp td-diffusion plot-timesteps -m 0 -m 1 -m 10 -m 100 -d 1 --dx 0.01 --dt 0.000025 -o diffusion_timesteps.png

# Stability condition doesn't hold
uv run scicomp td-diffusion plot-timesteps -m 0 -m 1 -m 10 -m 100 -d 1 --dx 0.01 --dt 0.0001
> Stability condition not met: 4*dt*D/dx^2 = 4.00 > 1. Do you want to proceed? [y/N]: n
> Aborted.
```

Example plot, generated using the first (stable) example above:
![diffusion_timesteps](https://github.com/user-attachments/assets/0e3fbd6f-99b9-46cd-886d-fd1aeb1aeeea)
