### PR TITLE
update uv; cache dependencies between runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.29"
+          version: "0.5.31"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Run tests
         run: uv run pytest


### PR DESCRIPTION
Closes #13. Updates uv in the GitHub Actions workflow, and caches dependencies (installed Python packages), speeding up CI runs.