### PR TITLE
Plot vibrating string at different timepoints

### DIFF
--- a/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
@@ -1,4 +1,4 @@
-from .grid_initialisation import initialize_grid
+from .grid_initialisation import Initialisation, initialize_grid
 
 
 def discretize_pde(
@@ -7,7 +7,7 @@ def discretize_pde(
     string_length: float,
     runtime: float,
     c: float,
-    case: int,
+    case: Initialisation,
 ):
     """
     Discretizes the second order vibration PDE in order to solve numerically.

--- a/src/scientific_computing/vibrating_strings_1d/utils/grid_initialisation.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/grid_initialisation.py
@@ -1,7 +1,17 @@
+from enum import StrEnum
+
 import numpy as np
 
 
-def initialize_string(spatial_intervals: int, case: int, string_length: int = 1):
+class Initialisation(StrEnum):
+    LowFreq = "low-freq"
+    HighFreq = "high-freq"
+    BoundedHighFreq = "bounded-high-freq"
+
+
+def initialize_string(
+    spatial_intervals: int, case: Initialisation, string_length: int = 1
+):
     """
     Initializes the starting wave of the string with the following three cases.
         i. Ψ(x, t = 0) = sin(2πx).
@@ -10,15 +20,16 @@ def initialize_string(spatial_intervals: int, case: int, string_length: int = 1)
     :return: Array representing the initial wave shape.
     """
     x = np.linspace(0, string_length, spatial_intervals + 1)
-    if case == 1:
-        return np.sin(2 * np.pi * x)
-    elif case == 2:
-        return np.sin(5 * np.pi * x)
-    elif case == 3:
-        return np.where((x > 1 / 5) & (x < 2 / 5), np.sin(5 * np.pi * x), 0)
+    match case:
+        case Initialisation.LowFreq:
+            return np.sin(2 * np.pi * x)
+        case Initialisation.HighFreq:
+            return np.sin(5 * np.pi * x)
+        case Initialisation.BoundedHighFreq:
+            return np.where((x > 1 / 5) & (x < 2 / 5), np.sin(5 * np.pi * x), 0)
 
 
-def initialize_grid(spatial_intervals: int, time_steps: int, case: int):
+def initialize_grid(spatial_intervals: int, time_steps: int, case: Initialisation):
     """
     Initializes grid for discretizing the second order PDE.
     :return: Initialized grid


### PR DESCRIPTION
Adds a CLI command to plot the 1D vibrating string at a list of timepoints. Closes #15.

Also refactors the string initialisation 'cases' to be an enum, so that this can be controlled easily via the CLI.

**Usage:**

```zsh
$ uv run scicomp string1d plot -m 0 -m 100 -m 200 -c 1

# To save image
$ uv run scicomp string1d plot -m 0 -m 100 -m 200 -c 1 --save-path vibrating_string.png
```

![vs](https://github.com/user-attachments/assets/eac20285-cab6-43ea-8af7-8339dc1da4aa)

