### PR TITLE
Add scheme-stability check

### DIFF
--- a/src/scientific_computing/time_dependent_diffusion/utils/__init__.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/__init__.py
@@ -1,3 +1,6 @@
 from .time_dependent_diffusion import (
+    is_stable_scheme as is_stable_scheme,
+)
+from .time_dependent_diffusion import (
     time_dependent_diffusion as time_dependent_diffusion,
 )

--- a/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
@@ -82,3 +82,8 @@ def plot_solution_comparison(dt: float, time_steps: int, intervals: int, terms: 
         ax.set_ylabel("Concentration (c)")
         ax.legend()
     plt.show()
+
+
+def is_stable_scheme(dt: float, dx: float, diffusivity: float) -> bool:
+    """Test if discretized diffusion scheme is stable."""
+    return 4 * dt * diffusivity / dx**2 <= 1

--- a/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
+++ b/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
@@ -20,6 +20,15 @@ def test_grid_shape(time_steps, intervals, dt, D):
     assert grid.shape == (intervals, intervals)
 
 
+@given(
+    intervals=integers(min_value=1),
+    dt=floats(min_value=0, max_value=1, allow_nan=False, allow_infinity=False),
+    D=floats(min_value=0, allow_nan=False, allow_infinity=False),
+)
+def test_is_stable_scheme(intervals, dt, D):
+    is_stable_scheme(dt, 1 / intervals, D)
+
+
 def test_diffusion_time_steps_and_intervals_less_than_one():
     with pytest.raises(ValueError):
         time_dependent_diffusion(time_steps=0, intervals=0, dt=0.01, D=5)

--- a/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
+++ b/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
@@ -1,8 +1,9 @@
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis.strategies import floats, integers
 
 from scientific_computing.time_dependent_diffusion.utils import (
+    is_stable_scheme,
     time_dependent_diffusion,
 )
 
@@ -14,6 +15,7 @@ from scientific_computing.time_dependent_diffusion.utils import (
     D=floats(min_value=0, allow_nan=False, allow_infinity=False),
 )
 def test_grid_shape(time_steps, intervals, dt, D):
+    assume(is_stable_scheme(dt, 1 / intervals, D))
     grid, _ = time_dependent_diffusion(time_steps, intervals, dt, D)
     assert grid.shape == (intervals, intervals)
 


### PR DESCRIPTION
Adds a function to check if a given scheme configuration for time-dependent diffusion is stable.

This is particularly useful in Hypothesis tests where we only want to run valid configurations. By including an "assume" statement which calls this function, Hypothesis will skip any configurations which are not stable.