### PR TITLE
Extend tests on vibrating string simulation

### DIFF
--- a/src/scientific_computing/cli.py
+++ b/src/scientific_computing/cli.py
@@ -112,7 +112,9 @@ def plot_vibrating_string(
 
 @vibrating_string.command(name="animate")
 def animate_vibrating_string(
-    case: Annotated[int, typer.Option(help="String initialisation")] = 1,
+    case: Annotated[
+        Initialisation, typer.Option(help="String initialisation")
+    ] = Initialisation.LowFreq,
     spatial_intervals: Annotated[
         int,
         typer.Option(

--- a/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
@@ -24,6 +24,12 @@ def discretize_pde(
 
     dt = runtime / temporal_intervals
     dx = string_length / spatial_intervals
+    if (courant := c * (dt / dx)) > 1.0:
+        raise ValueError(
+            f"Courant number exceeds 1.0, results may be inaccurate: "
+            f"c*(dt/dx) = {courant}."
+        )
+
     r = (c * dt / dx) ** 2
 
     grid = initialize_grid(spatial_intervals, temporal_intervals, case)

--- a/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
@@ -28,12 +28,18 @@ def discretize_pde(
 
     grid = initialize_grid(spatial_intervals, temporal_intervals, case)
 
-    for n in range(1, temporal_intervals - 1):
+    # Boundary (t=1), computed using symmetry at t=0 due to string at rest
+    for i in range(1, spatial_intervals):
+        grid[1, i] = (r / 2) * (
+            grid[0, i + 1] - 2 * grid[0, i] + grid[0, i - 1]
+        ) + grid[0, i]
+
+    for t in range(1, temporal_intervals - 1):
         for i in range(1, spatial_intervals):
-            grid[n + 1, i] = (
-                r * (grid[n, i + 1] - 2 * grid[n, i] + grid[n, i - 1])
-                + 2 * grid[n, i]
-                - grid[n - 1, i]
+            grid[t + 1, i] = (
+                r * (grid[t, i + 1] - 2 * grid[t, i] + grid[t, i - 1])
+                + 2 * grid[t, i]
+                - grid[t - 1, i]
             )
 
     return grid

--- a/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/discretize_pde.py
@@ -13,6 +13,15 @@ def discretize_pde(
     Discretizes the second order vibration PDE in order to solve numerically.
     :return: Computed wave grid over time.
     """
+    if spatial_intervals < 1:
+        raise ValueError(
+            f"Spatial intervals must be at least 1, found {spatial_intervals}"
+        )
+    if runtime < 1 or runtime > 1e10:
+        raise ValueError(f"Runtime must be in range [1,1e10], found: {runtime}")
+    if c > 1e10:
+        raise ValueError(f"Propagation velocity exceeds allowable range: 1e10 < {c}")
+
     dt = runtime / temporal_intervals
     dx = string_length / spatial_intervals
     r = (c * dt / dx) ** 2

--- a/src/scientific_computing/vibrating_strings_1d/utils/grid_initialisation.py
+++ b/src/scientific_computing/vibrating_strings_1d/utils/grid_initialisation.py
@@ -22,11 +22,14 @@ def initialize_string(
     x = np.linspace(0, string_length, spatial_intervals + 1)
     match case:
         case Initialisation.LowFreq:
-            return np.sin(2 * np.pi * x)
+            y = np.sin(2 * np.pi * x)
         case Initialisation.HighFreq:
-            return np.sin(5 * np.pi * x)
+            y = np.sin(5 * np.pi * x)
         case Initialisation.BoundedHighFreq:
-            return np.where((x > 1 / 5) & (x < 2 / 5), np.sin(5 * np.pi * x), 0)
+            y = np.where((x > 1 / 5) & (x < 2 / 5), np.sin(5 * np.pi * x), 0)
+
+    y[[0, spatial_intervals]] = 0.0
+    return y
 
 
 def initialize_grid(spatial_intervals: int, time_steps: int, case: Initialisation):
@@ -39,5 +42,4 @@ def initialize_grid(spatial_intervals: int, time_steps: int, case: Initialisatio
 
     grid = np.zeros((time_steps, spatial_intervals + 1))
     grid[0] = initialize_string(spatial_intervals, case)
-    grid[1] = grid[0]
     return grid

--- a/tests/vibrating_strings_1d/test_utils.py
+++ b/tests/vibrating_strings_1d/test_utils.py
@@ -1,8 +1,12 @@
 import pytest
-from hypothesis import given
-from hypothesis.strategies import integers
+from hypothesis import given, settings
+from hypothesis.strategies import floats, integers, sampled_from
 
+from scientific_computing.vibrating_strings_1d.utils.discretize_pde import (
+    discretize_pde,
+)
 from scientific_computing.vibrating_strings_1d.utils.grid_initialisation import (
+    Initialisation,
     initialize_grid,
 )
 
@@ -10,13 +14,54 @@ from scientific_computing.vibrating_strings_1d.utils.grid_initialisation import 
 @given(
     grid_intervals=integers(min_value=0, max_value=1000),
     time_points=integers(min_value=2, max_value=1000),
-    case=integers(min_value=1, max_value=3),
+    case=sampled_from(Initialisation),
 )
 def test_grid_shape(grid_intervals, time_points, case):
     grid = initialize_grid(grid_intervals, time_points, case)
     assert grid.shape == (time_points, grid_intervals + 1)
 
 
+@settings(deadline=None)
+@given(
+    spatial_intervals=integers(min_value=1, max_value=1000),
+    temporal_intervals=integers(min_value=2, max_value=1000),
+    runtime=floats(min_value=1, max_value=1e10),
+    propagation_velocity=floats(min_value=0, max_value=1e10),
+)
+def test_max_amplitude_always_at_most_initial_max(
+    spatial_intervals, temporal_intervals, runtime, propagation_velocity
+):
+    states = discretize_pde(
+        spatial_intervals,
+        temporal_intervals,
+        string_length=1,
+        runtime=runtime,
+        c=propagation_velocity,
+        case=Initialisation.LowFreq,
+    )
+    assert states[0].max() >= states.max()
+
+
+def test_string_simulation_raises_on_short_runtime():
+    with pytest.raises(ValueError):
+        discretize_pde(50, 100, 1, 0.99, c=1.0, case=Initialisation.LowFreq)
+
+
+def test_string_simulation_raises_on_zero_intervals():
+    with pytest.raises(ValueError):
+        discretize_pde(0, 100, 1, 100, c=1.0, case=Initialisation.LowFreq)
+
+
+def test_string_simulation_raises_on_large_velocity():
+    with pytest.raises(ValueError):
+        discretize_pde(1, 100, 1, 100, c=1e100, case=Initialisation.LowFreq)
+
+
+def test_string_simulation_raises_on_large_runtime():
+    with pytest.raises(ValueError):
+        discretize_pde(1, 100, 1, runtime=1e100, c=1, case=Initialisation.LowFreq)
+
+
 def test_initialize_grid_below_two_time_steps_fails():
     with pytest.raises(ValueError):
-        initialize_grid(spatial_intervals=50, time_steps=1, case=1)
+        initialize_grid(spatial_intervals=50, time_steps=1, case=Initialisation.LowFreq)

--- a/tests/vibrating_strings_1d/test_utils.py
+++ b/tests/vibrating_strings_1d/test_utils.py
@@ -62,6 +62,18 @@ def test_string_simulation_raises_on_large_runtime():
         discretize_pde(1, 100, 1, runtime=1e100, c=1, case=Initialisation.LowFreq)
 
 
+def test_string_simulation_raises_on_courant_gt_1():
+    with pytest.raises(ValueError):
+        discretize_pde(
+            spatial_intervals=3,
+            temporal_intervals=2,
+            runtime=1,
+            string_length=1,
+            c=1,
+            case=Initialisation.LowFreq,
+        )
+
+
 def test_initialize_grid_below_two_time_steps_fails():
     with pytest.raises(ValueError):
         initialize_grid(spatial_intervals=50, time_steps=1, case=Initialisation.LowFreq)


### PR DESCRIPTION
Changes:
- Add parameter-value checks to vibrating string simulation
- Fix boundary conditions and equation in vibrating string simulation
- Add tests to verify exceptions raised for invalid parameters
- Add test to check that maximum observed amplitude never greater than initial maximum

## Parameter-value checks
Testing with hypothesis identified parameter values which cause the simulation to crash, overflow, or produce inaccurate results. This PR implements the following allowable domains for parameters:
- `spatial_intervals`: Negative and zero values not realistic. Given a minimum value of 1.
- `runtime`: Extremely small values cause numerical instability (e.g. runtime $1e-100$). Large values lead to extremely long simulation times. Allowable range set to $[1, 1e10]$.
- `c` (propagation velocity): Large values cause numerical instability. Allowable range set to $(-\infty, 1e10]$. 
Adds a few parameter-value checks to identify cases which break the simulation, and implements tests to check that these checks work as intended.

In addition to this, the PR implements a check for stability using the Courant number, $c \frac{dt}{dx}$. If this exceeds $1.0$, the simulation is likely to produce inaccurate results. I observed this when testing the expected observed maximum amplitude (see below).

## Observed maximum amplitude
Since the string begins at rest, we expect that the maximum amplitude observed anywhere in the string throughout the simulation should not exceed the maximum amplitude observed at the start of the simulation.

I've implemented a hypothesis test to verify this behaviour. The test fails when the Courant number $C = c \frac{dt}{dx} > 1.0$. Intuitively, for small step-sizes in the spatial domain, we also need small temporal steps. 

When we only consider cases where $C \leq 1.0$, the test succeeds generally, but can fail due to numerical instability. 

Interestingly, I found hypothesis to be a useful method for testing the error propagation throughout a simulation. We check the above condition (_"is the maximum observed amplitude greater than the initial maximum amplitude"_) with a given error tolerance, i.e. allowing the observed maximum to be **slightly** greater due to numerical precision errors. For low tolerance (allowing errors of ~$1e-13$), the simulation breaks after 810 time-steps. As the tolerance is decreased, the number of time-steps before the simulation breaks decreases, by a factor of about 10 per extra digit of required precision.

## Boundary conditions
I found two issues with the boundary conditions:
1. The initial amplitude of the string at $x=L$ was not quite zero.
2. The calculation for the first timestep is slightly incorrect.

In the first case, I found that the initial amplitude at $x=L$ was almost, but not quite, zero. This results from it being calculated using the sine function, rather than being set explicitly to zero.

In the second case, we currently assume that the first two states of the system are identical (maybe due to the gradient being zero at the start?). However, this implies that the second derivative is also zero at the start (I think).

Since the system begins at rest, we can assume that $\Psi(x, 0 + \delta t) = \Psi(x, 0 - \delta t)$, i.e. the state just after $t=0$ is the same as just _before_ $t=0$. Making this substitution in our update equation, we obtain a separate update equation for the first step, for $x \in (0, L)$:

$$\Psi(x, 0 + \delta t) = \frac{r}{2}[\Psi(x - \delta x, 0) + \Psi(x + \delta x, 0) - 2\Psi(x, 0)] + \Psi(x, 0)$$

I found that this was actually required in order for the Courant number bound to ensure correct results.