### PR TITLE
Implement time-independent methods in numba

### DIFF
--- a/src/scientific_computing/_core.pyi
+++ b/src/scientific_computing/_core.pyi
@@ -1,4 +1,8 @@
 def hello_from_bin() -> str: ...
 def td_diffusion_cylinder(
-    measurement_timesteps: list[int], intervals: int, dt: float, diffusivity: float
+    measurement_timesteps: list[int],
+    intervals: int,
+    dt: float,
+    diffusivity: float,
+    rect_sinks: list[tuple[int, int, int, int]],
 ): ...

--- a/src/scientific_computing/cli.py
+++ b/src/scientific_computing/cli.py
@@ -188,6 +188,88 @@ def animate_vibrating_string(
 
 
 @td_diffusion.command()
+def jacobi(
+    n: Annotated[
+        int,
+        typer.Option("-n", help="Number of intervals to divide spatial domain into."),
+    ] = 50,
+    diffusivity: Annotated[
+        float,
+        typer.Option("--diffusivity", "-d", help="Diffusivity coefficient"),
+    ] = 1.0,
+    epsilon: Annotated[
+        float,
+        typer.Option("--epsilon", "-e", help="Convergence threshold."),
+    ] = 1e-6,
+    max_iters: Annotated[
+        int,
+        typer.Option("--max-iters", help="Maximum iterations before termination."),
+    ] = 100_000,
+):
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    cylinder.solve_jacobi(epsilon=epsilon, max_iters=max_iters)
+    plt.imshow(cylinder.grid)
+    plt.show()
+
+
+@td_diffusion.command()
+def gauss_seidel(
+    n: Annotated[
+        int,
+        typer.Option("-n", help="Number of intervals to divide spatial domain into."),
+    ] = 50,
+    diffusivity: Annotated[
+        float,
+        typer.Option("--diffusivity", "-d", help="Diffusivity coefficient"),
+    ] = 1.0,
+    epsilon: Annotated[
+        float,
+        typer.Option("--epsilon", "-e", help="Convergence threshold."),
+    ] = 1e-6,
+    max_iters: Annotated[
+        int,
+        typer.Option("--max-iters", help="Maximum iterations before termination."),
+    ] = 100_000,
+):
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    cylinder.solve_gauss_seidel(epsilon=epsilon, max_iters=max_iters)
+    plt.imshow(cylinder.grid)
+    plt.show()
+
+
+@td_diffusion.command()
+def sor(
+    omega: Annotated[
+        float,
+        typer.Option(
+            "--omega",
+            "-w",
+        ),
+    ],
+    n: Annotated[
+        int,
+        typer.Option("-n", help="Number of intervals to divide spatial domain into."),
+    ] = 50,
+    diffusivity: Annotated[
+        float,
+        typer.Option("--diffusivity", "-d", help="Diffusivity coefficient"),
+    ] = 1.0,
+    epsilon: Annotated[
+        float,
+        typer.Option("--epsilon", "-e", help="Convergence threshold."),
+    ] = 1e-6,
+    max_iters: Annotated[
+        int,
+        typer.Option("--max-iters", help="Maximum iterations before termination."),
+    ] = 100_000,
+):
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    cylinder.solve_sor(omega=omega, epsilon=epsilon, max_iters=max_iters)
+    plt.imshow(cylinder.grid)
+    plt.show()
+
+
+@td_diffusion.command()
 def plot_timesteps(
     measurement_times: Annotated[
         list[float],

--- a/src/scientific_computing/cli.py
+++ b/src/scientific_computing/cli.py
@@ -10,6 +10,7 @@ from scientific_computing.animation import (
 )
 from scientific_computing.time_dependent_diffusion import (
     Cylinder,
+    Rectangle,
     RunMode,
     plot_solution_comparison,
     time_dependent_diffusion_numba,
@@ -41,6 +42,24 @@ td_diffusion = typer.Typer(
 
 app.add_typer(vibrating_string)
 app.add_typer(td_diffusion)
+
+
+def parse_rect_sinks(
+    rectangle_sinks: list[str] | None,
+) -> list[Rectangle]:
+    if rectangle_sinks:
+        sinks = []
+        for s in rectangle_sinks:
+            s = s.split(" ")
+            if len(s) != 4:
+                raise ValueError(
+                    f"Rectangles should be in format 'x y w h', found: {s}"
+                )
+            x, y, w, h = s
+            sinks.append((float(x), float(y), float(w), float(h)))
+    else:
+        sinks = []
+    return sinks
 
 
 @app.command()
@@ -205,8 +224,13 @@ def jacobi(
         int,
         typer.Option("--max-iters", help="Maximum iterations before termination."),
     ] = 100_000,
+    rectangle_sinks: Annotated[
+        list[str] | None,
+        typer.Option("--sink-rect", help="Location of a rectangular sink: 'x y w h'."),
+    ] = None,
 ):
-    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    sinks = parse_rect_sinks(rectangle_sinks)
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity, sinks=sinks)
     cylinder.solve_jacobi(epsilon=epsilon, max_iters=max_iters)
     plt.imshow(cylinder.grid)
     plt.show()
@@ -230,8 +254,13 @@ def gauss_seidel(
         int,
         typer.Option("--max-iters", help="Maximum iterations before termination."),
     ] = 100_000,
+    rectangle_sinks: Annotated[
+        list[str] | None,
+        typer.Option("--sink-rect", help="Location of a rectangular sink: 'x y w h'."),
+    ] = None,
 ):
-    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    sinks = parse_rect_sinks(rectangle_sinks)
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity, sinks=sinks)
     cylinder.solve_gauss_seidel(epsilon=epsilon, max_iters=max_iters)
     plt.imshow(cylinder.grid)
     plt.show()
@@ -262,8 +291,13 @@ def sor(
         int,
         typer.Option("--max-iters", help="Maximum iterations before termination."),
     ] = 100_000,
+    rectangle_sinks: Annotated[
+        list[str] | None,
+        typer.Option("--sink-rect", help="Location of a rectangular sink: 'x y w h'."),
+    ] = None,
 ):
-    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity)
+    sinks = parse_rect_sinks(rectangle_sinks)
+    cylinder = Cylinder(spatial_intervals=n, diffusivity=diffusivity, sinks=sinks)
     cylinder.solve_sor(omega=omega, epsilon=epsilon, max_iters=max_iters)
     plt.imshow(cylinder.grid)
     plt.show()
@@ -307,6 +341,10 @@ def plot_timesteps(
         RunMode,
         typer.Option(help="Simulation mode."),
     ] = RunMode.Numba,
+    rectangle_sinks: Annotated[
+        list[str] | None,
+        typer.Option("--sink-rect", help="Location of a rectangular sink: 'x y w h'."),
+    ] = None,
 ):
     # Check stability condition
     if (stability_cond := (4 * dt * diffusivity) / (dx**2)) > 1:
@@ -321,17 +359,19 @@ def plot_timesteps(
     if not measurement_times:
         raise ValueError("Measurements list should be non-empty.")
 
-    # Initialise grid
-    # TODO: What if dx doesn't divide width? How do we tell with floating point
-    #   arithmetic?
+    spatial_intervals = int(width / dx)
+    sinks = parse_rect_sinks(rectangle_sinks)
+
+    cylinder = Cylinder(
+        spatial_intervals=spatial_intervals,
+        diffusivity=diffusivity,
+        sinks=sinks,
+    )
+    grids = cylinder.measure(measurement_times=measurement_times, dt=dt, mode=mode)
 
     ncol = 2
     nrow = len(measurement_times) // ncol + len(measurement_times) % ncol
     fig, axes = plt.subplots(nrow, ncol, layout="constrained", sharex=True, sharey=True)
-
-    spatial_intervals = int(width / dx)
-    cylinder = Cylinder(spatial_intervals=spatial_intervals, diffusivity=diffusivity)
-    grids = cylinder.measure(measurement_times=measurement_times, dt=dt, mode=mode)
     for grid, ax in zip(grids, axes.flatten(), strict=True):
         ax.imshow(grid, extent=[0, width, 0, width], vmin=0, vmax=1)
 

--- a/src/scientific_computing/time_dependent_diffusion/__init__.py
+++ b/src/scientific_computing/time_dependent_diffusion/__init__.py
@@ -2,17 +2,14 @@ from .utils.animation import (
     animate_diffusion as animate_diffusion,
 )
 from .utils.time_dependent_diffusion import (
-    one_step_diffusion as one_step_diffusion,
+    Cylinder as Cylinder,
 )
 from .utils.time_dependent_diffusion import (
-    one_step_diffusion_numba as one_step_diffusion_numba,
+    RunMode as RunMode,
+)
+from .utils.time_dependent_diffusion import (
+    is_stable_scheme as is_stable_scheme,
 )
 from .utils.time_dependent_diffusion import (
     plot_solution_comparison as plot_solution_comparison,
-)
-from .utils.time_dependent_diffusion import (
-    time_dependent_diffusion as time_dependent_diffusion,
-)
-from .utils.time_dependent_diffusion import (
-    time_dependent_diffusion_numba as time_dependent_diffusion_numba,
 )

--- a/src/scientific_computing/time_dependent_diffusion/__init__.py
+++ b/src/scientific_computing/time_dependent_diffusion/__init__.py
@@ -5,6 +5,9 @@ from .utils.time_dependent_diffusion import (
     Cylinder as Cylinder,
 )
 from .utils.time_dependent_diffusion import (
+    Rectangle as Rectangle,
+)
+from .utils.time_dependent_diffusion import (
     RunMode as RunMode,
 )
 from .utils.time_dependent_diffusion import (

--- a/src/scientific_computing/time_dependent_diffusion/utils/__init__.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/__init__.py
@@ -1,9 +1,9 @@
 from .time_dependent_diffusion import (
     is_stable_scheme as is_stable_scheme,
 )
-from .time_dependent_diffusion import (
-    time_dependent_diffusion as time_dependent_diffusion,
-)
-from .time_dependent_diffusion import (
-    time_dependent_diffusion_numba as time_dependent_diffusion_numba,
-)
+# from .time_dependent_diffusion import (
+#    time_dependent_diffusion as time_dependent_diffusion,
+# )
+# from .time_dependent_diffusion import (
+#    time_dependent_diffusion_numba as time_dependent_diffusion_numba,
+# )

--- a/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
@@ -1,8 +1,83 @@
+from enum import StrEnum
+
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from numba import njit
 from scipy.special import erfc
+
+from scientific_computing._core import td_diffusion_cylinder
+
+
+class RunMode(StrEnum):
+    Python = "python"
+    Numba = "numba"
+    Rust = "rust"
+
+
+class Cylinder:
+    def __init__(self, spatial_intervals: int, diffusivity: float):
+        self.grid = np.zeros((spatial_intervals, spatial_intervals), dtype=np.float64)
+        self.grid[0] = 1.0
+        self.dx = 1 / spatial_intervals
+        self.diffusivity = diffusivity
+
+    def run(self, n_iters: int, dt: float, mode: RunMode = RunMode.Python):
+        if n_iters < 0:
+            raise ValueError("n_iters must be positive.")
+
+        match mode:
+            case RunMode.Python:
+                update = one_step_diffusion
+            case RunMode.Numba:
+                update = one_step_diffusion_numba
+            case RunMode.Rust:
+                self.grid = td_diffusion_cylinder(
+                    [n_iters],
+                    intervals=self.grid.shape[0],
+                    dt=dt,
+                    diffusivity=self.diffusivity,
+                )[-1]
+                return
+
+        buffer = np.zeros_like(self.grid)
+        for _ in range(n_iters):
+            self.grid = update(self.grid, buffer, dt, self.dx, self.diffusivity)
+
+    def measure(
+        self, measurement_times: list[float], dt: float, mode: RunMode = RunMode.Python
+    ):
+        if len(measurement_times) == 0:
+            raise ValueError("Must specify at least one measurement time.")
+        elif min(measurement_times) < 0.0 or max(measurement_times) > 1.0:
+            raise ValueError("Measurement times must be in interval [0,1]")
+        measurement_idxes = set(int(t / dt) for t in measurement_times)
+
+        match mode:
+            case RunMode.Python:
+                update = one_step_diffusion
+            case RunMode.Numba:
+                update = one_step_diffusion_numba
+            case RunMode.Rust:
+                measurements = td_diffusion_cylinder(
+                    list(measurement_idxes),
+                    intervals=self.grid.shape[0],
+                    dt=dt,
+                    diffusivity=self.diffusivity,
+                )
+                self.grid = measurements[-1].copy()
+                return measurements
+
+        measurements = []
+        time_steps = max(measurement_idxes)
+
+        buffer = np.zeros_like(self.grid)
+        for t in range(time_steps + 1):
+            if t in measurement_idxes:
+                measurements.append(self.grid.copy())
+            self.grid = update(self.grid, buffer, dt, self.dx, self.diffusivity)
+
+        return measurements
 
 
 @njit
@@ -33,27 +108,13 @@ def one_step_diffusion_numba(
     return grid
 
 
-def time_dependent_diffusion_numba(
-    time_steps: int, intervals: int, dt: float, D: float
+def one_step_diffusion(
+    grid: npt.NDArray[np.float64],
+    buffer: npt.NDArray[np.float64],
+    dt: float,
+    dx: float,
+    D: float,
 ):
-    if time_steps < 1:
-        raise ValueError("Time steps must be greater than 2.")
-
-    grid = np.zeros((intervals, intervals), dtype=np.float64)
-    grid[0] = 1
-    dx = 1 / intervals
-
-    buffer = np.zeros((intervals, intervals), dtype=np.float64)
-    grid_history = [grid.copy()]
-    for _ in range(time_steps):
-        grid = one_step_diffusion_numba(grid, buffer, dt, dx, D)
-        grid_history.append(grid.copy())
-
-    return grid, grid_history
-
-
-def one_step_diffusion(grid: npt.NDArray[np.float64], dt: float, dx: float, D: float):
-    new_grid = grid.copy()
     diffusion_coeff = (dt * D) / (dx**2)
     for i in range(1, grid.shape[0] - 1):
         for j in range(0, grid.shape[1]):
@@ -64,26 +125,10 @@ def one_step_diffusion(grid: npt.NDArray[np.float64], dt: float, dx: float, D: f
                 + grid[i, (j - 1) % grid.shape[1]]  # Left neighbor
                 - 4 * grid[i, j]  # Self
             )
+            buffer[i, j] = grid[i, j] + diffusion_coeff * neighbor_concentration_diff
 
-            new_grid[i, j] = grid[i, j] + diffusion_coeff * neighbor_concentration_diff
-            # grid[i, j] = new_grid[i, j]
-    return new_grid
-
-
-def time_dependent_diffusion(time_steps: int, intervals: int, dt: float, D: float):
-    if time_steps < 1:
-        raise ValueError("Time steps must be greater than 2.")
-
-    grid = np.zeros((intervals, intervals), dtype=np.float64)
-    grid[0] = 1
-    dx = 1 / intervals
-
-    grid_history = [grid.copy()]
-    for _ in range(time_steps):
-        grid = one_step_diffusion(grid, dt, dx, D)
-        grid_history.append(grid.copy())
-
-    return grid, grid_history
+    grid[1:-1, ...] = buffer[1:-1, ...]
+    return grid
 
 
 def analytical_solution(y: float, D: float, t: float, terms: int):
@@ -95,24 +140,26 @@ def analytical_solution(y: float, D: float, t: float, terms: int):
     return solution
 
 
-def plot_solution_comparison(dt: float, time_steps: int, intervals: int, terms: int):
-    t_range = [0.001, 0.01, 0.1, 1.0]
+def plot_solution_comparison(
+    dt: float,
+    measurement_times: list[float],
+    intervals: int,
+    terms: int,
+    mode: RunMode = RunMode.Python,
+):
     y_range = np.linspace(0, 1, intervals)
     D = 1
 
     fig, axes = plt.subplots(2, 2, figsize=(10, 10))
     axes = axes.flatten()
 
-    simulation_result, grid_history = time_dependent_diffusion(
-        time_steps, intervals, dt, D
+    cylinder = Cylinder(spatial_intervals=intervals, diffusivity=D)
+    measurements = cylinder.measure(
+        measurement_times=measurement_times, dt=dt, mode=mode
     )
 
-    for idx, t in enumerate(t_range):
-        time_step_idx = int(t / dt)
-        if time_step_idx >= len(grid_history):
-            grid_at_t = grid_history[-1]
-        else:
-            grid_at_t = grid_history[time_step_idx]
+    for idx, t in enumerate(measurement_times):
+        grid_at_t = measurements[idx]
         simulation_result_y = grid_at_t[::-1, 0]
         analytical_result_y = [analytical_solution(y, D, t, terms) for y in y_range]
 

--- a/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
@@ -315,7 +315,7 @@ def one_step_diffusion_numba(
     dt: float,
     dx: float,
     D: float,
-    rectangle_sinks: list[tuple[int, int, int, int]],
+    rectangle_sinks,
 ):
     diffusion_coeff = (dt * D) / (dx**2)
     for i in range(1, grid.shape[0] - 1):

--- a/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
+++ b/src/scientific_computing/time_dependent_diffusion/utils/time_dependent_diffusion.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from enum import StrEnum
 
 import matplotlib.pyplot as plt
@@ -8,6 +9,10 @@ from scipy.special import erfc
 
 from scientific_computing._core import td_diffusion_cylinder
 
+type Rectangle = tuple[float, float, float, float]
+type Circle = tuple[float, float, float]
+type DomainObjects = Sequence[Rectangle | Circle]
+
 
 class RunMode(StrEnum):
     Python = "python"
@@ -16,11 +21,52 @@ class RunMode(StrEnum):
 
 
 class Cylinder:
-    def __init__(self, spatial_intervals: int, diffusivity: float):
+    rectangle_sinks: list[tuple[int, int, int, int]]
+
+    def __init__(
+        self,
+        spatial_intervals: int,
+        diffusivity: float,
+        sinks: DomainObjects | None = None,
+    ):
         self.grid = np.zeros((spatial_intervals, spatial_intervals), dtype=np.float64)
         self.grid[0] = 1.0
         self.dx = 1 / spatial_intervals
         self.diffusivity = diffusivity
+        self.init_objects(sinks=sinks, dx=self.dx)
+
+    def discretise_coord(self, coord: float) -> int:
+        return int(coord / self.dx)
+
+    def init_objects(self, sinks: DomainObjects | None, dx: float):
+        def discretise_rect(rect: Rectangle) -> tuple[int, int, int, int]:
+            return (
+                self.discretise_coord(rect[0]),
+                self.discretise_coord(rect[1]),
+                self.discretise_coord(rect[2]),
+                self.discretise_coord(rect[3]),
+            )
+
+        if sinks is None:
+            self.rectangle_sinks = [(0, 0, 0, 0)]
+            self.circle_sinks = []
+        else:
+            rectangle_sinks = [(0, 0, 0, 0)]
+            circle_sinks = []
+            for obj in sinks:
+                match obj:
+                    case (_, _, _, _):
+                        if not all(0 <= v <= 1 for v in obj):
+                            raise ValueError(
+                                f"Rectangle must fit inside cylinder with dimensions "
+                                f"1x1. Found rectangle of shape: {obj}."
+                            )
+                        rectangle_sinks.append(discretise_rect(obj))
+                    case (_, _, _):
+                        raise NotImplementedError
+                        # circle_sinks.append(obj)
+            self.rectangle_sinks = rectangle_sinks
+            self.circle_sinks = circle_sinks
 
     def run(self, n_iters: int, dt: float, mode: RunMode = RunMode.Python):
         if n_iters < 0:
@@ -37,20 +83,23 @@ class Cylinder:
                     intervals=self.grid.shape[0],
                     dt=dt,
                     diffusivity=self.diffusivity,
+                    rect_sinks=self.rectangle_sinks[1:],
                 )[-1]
                 return
 
         buffer = np.zeros_like(self.grid)
         for _ in range(n_iters):
-            self.grid = update(self.grid, buffer, dt, self.dx, self.diffusivity)
+            self.grid = update(
+                self.grid, buffer, dt, self.dx, self.diffusivity, self.rectangle_sinks
+            )
 
     def measure(
         self, measurement_times: list[float], dt: float, mode: RunMode = RunMode.Python
     ):
         if len(measurement_times) == 0:
             raise ValueError("Must specify at least one measurement time.")
-        elif min(measurement_times) < 0.0 or max(measurement_times) > 1.0:
-            raise ValueError("Measurement times must be in interval [0,1]")
+        elif min(measurement_times) < 0.0:  # or max(measurement_times) > 1.0:
+            raise ValueError("Measurement times must be greater than zero.")
         measurement_idxes = set(int(t / dt) for t in measurement_times)
 
         match mode:
@@ -64,6 +113,7 @@ class Cylinder:
                     intervals=self.grid.shape[0],
                     dt=dt,
                     diffusivity=self.diffusivity,
+                    rect_sinks=self.rectangle_sinks[1:],
                 )
                 self.grid = measurements[-1].copy()
                 return measurements
@@ -75,7 +125,9 @@ class Cylinder:
         for t in range(time_steps + 1):
             if t in measurement_idxes:
                 measurements.append(self.grid.copy())
-            self.grid = update(self.grid, buffer, dt, self.dx, self.diffusivity)
+            self.grid = update(
+                self.grid, buffer, dt, self.dx, self.diffusivity, self.rectangle_sinks
+            )
 
         return measurements
 
@@ -93,10 +145,10 @@ class Cylinder:
 
         old_grid = self.grid
         buffer = np.empty_like(old_grid)
-        new_grid, diff = update(old_grid, buffer)
+        new_grid, diff = update(old_grid, buffer, self.rectangle_sinks)
         iters = 1
         while diff > epsilon and iters < max_iters:
-            new_grid, diff = update(new_grid, buffer)
+            new_grid, diff = update(new_grid, buffer, self.rectangle_sinks)
             iters += 1
         if iters < max_iters:
             print(f"Converged after {iters} iterations.")
@@ -117,10 +169,10 @@ class Cylinder:
                 raise NotImplementedError(f"Unsupported run mode for Jacobi: {mode}")
 
         old_grid = self.grid
-        new_grid, diff = update(old_grid)
+        new_grid, diff = update(old_grid, self.rectangle_sinks)
         iters = 1
         while diff > epsilon and iters < max_iters:
-            new_grid, diff = update(new_grid)
+            new_grid, diff = update(new_grid, self.rectangle_sinks)
             iters += 1
         if iters < max_iters:
             print(f"Converged after {iters} iterations.")
@@ -142,10 +194,10 @@ class Cylinder:
                 raise NotImplementedError(f"Unsupported run mode for Jacobi: {mode}")
 
         old_grid = self.grid
-        new_grid, diff = update(old_grid, omega)
+        new_grid, diff = update(old_grid, omega, self.rectangle_sinks)
         iters = 1
         while diff > epsilon and iters < max_iters:
-            new_grid, diff = update(new_grid, omega)
+            new_grid, diff = update(new_grid, omega, self.rectangle_sinks)
             iters += 1
         if iters < max_iters:
             print(f"Converged after {iters} iterations.")
@@ -158,6 +210,7 @@ class Cylinder:
 def jacobi_update_numba(
     grid: npt.NDArray[np.float64],
     buffer: npt.NDArray[np.float64],
+    rectangle_sinks: list[tuple[int, int, int, int]],
 ):
     for i in range(1, grid.shape[0] - 1):
         for j in range(0, grid.shape[1]):
@@ -167,6 +220,11 @@ def jacobi_update_numba(
                 + grid[i, (j + 1) % grid.shape[1]]  # East
                 + grid[i, (j - 1) % grid.shape[1]]  # West
             )
+
+    for x, y, w, h in rectangle_sinks[1:]:
+        for i in range(y, y + h):
+            for j in range(x, x + w):
+                buffer[i, j % grid.shape[1]] = 0.0
 
     max_diff = 0.0
     for i in range(1, grid.shape[0] - 1):
@@ -180,12 +238,30 @@ def jacobi_update_numba(
 
 
 @njit
+def contained_in_some_rect(
+    row: int, col: int, rectangles: list[tuple[int, int, int, int]], ncol: int
+) -> bool:
+    for x, y, w, h in rectangles:
+        if row < y or col < x:
+            continue
+        if row >= y + h or col >= ((x + w) % ncol):
+            continue
+        return True
+    return False
+
+
+@njit
 def gauss_seidel_update_numba(
     grid: npt.NDArray[np.float64],
+    rectangle_sinks: list[tuple[int, int, int, int]],
 ):
+    rectangle_sinks = rectangle_sinks[1:]
     max_diff = 0.0
     for i in range(1, grid.shape[0] - 1):
         for j in range(0, grid.shape[1]):
+            if contained_in_some_rect(i, j, rectangle_sinks, ncol=grid.shape[1]):
+                grid[i, j] = 0.0
+                continue
             new_val = 0.25 * (
                 grid[i - 1, j]  # North
                 + grid[i + 1, j]  # South
@@ -204,10 +280,15 @@ def gauss_seidel_update_numba(
 def sor_update_numba(
     grid: npt.NDArray[np.float64],
     omega: float,
+    rectangle_sinks: list[tuple[int, int, int, int]],
 ):
+    rectangle_sinks = rectangle_sinks[1:]
     max_diff = 0.0
     for i in range(1, grid.shape[0] - 1):
         for j in range(0, grid.shape[1]):
+            if contained_in_some_rect(i, j, rectangle_sinks, ncol=grid.shape[1]):
+                grid[i, j] = 0.0
+                continue
             new_val = (
                 omega
                 * 0.25
@@ -234,6 +315,7 @@ def one_step_diffusion_numba(
     dt: float,
     dx: float,
     D: float,
+    rectangle_sinks: list[tuple[int, int, int, int]],
 ):
     diffusion_coeff = (dt * D) / (dx**2)
     for i in range(1, grid.shape[0] - 1):
@@ -247,6 +329,11 @@ def one_step_diffusion_numba(
             )
 
             buffer[i, j] = grid[i, j] + diffusion_coeff * neighbor_concentration_diff
+
+    for x, y, w, h in rectangle_sinks[1:]:
+        for i in range(y, y + h):
+            for j in range(x, x + w):
+                buffer[i, j % grid.shape[1]] = 0.0
 
     for i in range(1, grid.shape[0] - 1):
         for j in range(0, grid.shape[1]):
@@ -261,6 +348,7 @@ def one_step_diffusion(
     dt: float,
     dx: float,
     D: float,
+    rectangle_sinks: list[tuple[int, int, int, int]],
 ):
     diffusion_coeff = (dt * D) / (dx**2)
     for i in range(1, grid.shape[0] - 1):
@@ -273,6 +361,11 @@ def one_step_diffusion(
                 - 4 * grid[i, j]  # Self
             )
             buffer[i, j] = grid[i, j] + diffusion_coeff * neighbor_concentration_diff
+
+    for x, y, w, h in rectangle_sinks[1:]:
+        for i in range(y, y + h):
+            for j in range(x, x + w):
+                buffer[i, j % grid.shape[1]] = 0
 
     grid[1:-1, ...] = buffer[1:-1, ...]
     return grid

--- a/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
+++ b/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
@@ -85,12 +85,6 @@ def test_diffusion_measure_raises_on_measure_time_lt_0():
         cylinder.measure(measurement_times=[-0.0001, 0.1, 0.5], dt=0.01)
 
 
-def test_diffusion_measure_raises_on_measure_time_gt_1():
-    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
-    with pytest.raises(ValueError):
-        cylinder.measure(measurement_times=[0.1, 1.0001, 0.5], dt=0.01)
-
-
 def test_diffusion_measure_okay_ok_valid_measure_times():
     cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
     cylinder.measure(measurement_times=[0.0, 0.1, 0.5, 1.0], dt=0.01)

--- a/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
+++ b/tests/time_dependent_diffusion/test_time_dependent_diffusion_utils.py
@@ -3,11 +3,10 @@ import pytest
 from hypothesis import assume, given, settings
 from hypothesis.strategies import floats, integers
 
-from scientific_computing._core import td_diffusion_cylinder
-from scientific_computing.time_dependent_diffusion.utils import (
+from scientific_computing.time_dependent_diffusion import (
+    Cylinder,
+    RunMode,
     is_stable_scheme,
-    time_dependent_diffusion,
-    time_dependent_diffusion_numba,
 )
 
 
@@ -20,8 +19,8 @@ from scientific_computing.time_dependent_diffusion.utils import (
 )
 def test_grid_shape(time_steps, intervals, dt, D):
     assume(is_stable_scheme(dt, 1 / intervals, D))
-    grid, _ = time_dependent_diffusion(time_steps, intervals, dt, D)
-    assert grid.shape == (intervals, intervals)
+    cylinder = Cylinder(spatial_intervals=intervals, diffusivity=D)
+    assert cylinder.grid.shape == (intervals, intervals)
 
 
 @given(
@@ -42,10 +41,12 @@ def test_is_stable_scheme(intervals, dt, D):
 )
 def test_numba_version_gives_same_results(time_steps, intervals, dt, D):
     assume(is_stable_scheme(dt, 1 / intervals, D))
-    grid_python, _ = time_dependent_diffusion(time_steps, intervals, dt, D)
-    grid_numba, _ = time_dependent_diffusion_numba(time_steps, intervals, dt, D)
+    cylinder_python = Cylinder(intervals, diffusivity=D)
+    cylinder_python.run(time_steps, dt, mode=RunMode.Python)
+    cylinder_numba = Cylinder(intervals, diffusivity=D)
+    cylinder_numba.run(time_steps, dt, mode=RunMode.Numba)
 
-    np.testing.assert_allclose(grid_python, grid_numba)
+    np.testing.assert_allclose(cylinder_python.grid, cylinder_numba.grid)
 
 
 @settings(deadline=None)
@@ -57,12 +58,39 @@ def test_numba_version_gives_same_results(time_steps, intervals, dt, D):
 )
 def test_rust_version_gives_same_results(time_steps, intervals, dt, D):
     assume(is_stable_scheme(dt, 1 / intervals, D))
-    grid_python, _ = time_dependent_diffusion(time_steps, intervals, dt, D)
-    grid_rust = td_diffusion_cylinder([time_steps], intervals, dt, D)[0]
 
-    np.testing.assert_allclose(grid_python, grid_rust)
+    cylinder_python = Cylinder(intervals, diffusivity=D)
+    cylinder_python.run(time_steps, dt, mode=RunMode.Python)
+    cylinder_rust = Cylinder(intervals, diffusivity=D)
+    cylinder_rust.run(time_steps, dt, mode=RunMode.Rust)
+
+    np.testing.assert_allclose(cylinder_python.grid, cylinder_rust.grid)
 
 
-def test_diffusion_time_steps_and_intervals_less_than_one():
+def test_diffusion_run_raises_on_neg_iters():
+    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
     with pytest.raises(ValueError):
-        time_dependent_diffusion(time_steps=0, intervals=0, dt=0.01, D=5)
+        cylinder.run(n_iters=-1, dt=0.01)
+
+
+def test_diffusion_measure_raises_on_no_measure_times():
+    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
+    with pytest.raises(ValueError):
+        cylinder.measure(measurement_times=[], dt=0.01)
+
+
+def test_diffusion_measure_raises_on_measure_time_lt_0():
+    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
+    with pytest.raises(ValueError):
+        cylinder.measure(measurement_times=[-0.0001, 0.1, 0.5], dt=0.01)
+
+
+def test_diffusion_measure_raises_on_measure_time_gt_1():
+    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
+    with pytest.raises(ValueError):
+        cylinder.measure(measurement_times=[0.1, 1.0001, 0.5], dt=0.01)
+
+
+def test_diffusion_measure_okay_ok_valid_measure_times():
+    cylinder = Cylinder(spatial_intervals=4, diffusivity=5)
+    cylinder.measure(measurement_times=[0.0, 0.1, 0.5, 1.0], dt=0.01)


### PR DESCRIPTION
Moves the time-dependent diffusion methods into a class alongside the initialisation code, and implements the time-_independent_ methods on the same class, calling out to Numba-optimised functions. Refactors code which uses this code so that it still works :) 