### PR TITLE
Add GitHub Action to produce effort distribution document

### DIFF
--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -17,7 +17,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.6.0"
-      
+
+      - name: Install Typst
+        uses: typst-community/setup-typst@v4
+
       - name: Compute distribution
         run: uvx git-fame --excl "uv.lock,assignment_spec.pdf,LICENSE.md,README.md,pyproject.toml,.gitignore,.pre-commit-config.yaml" --no-regex -M -C --format csv > reports/git_fame_output.csv
 
@@ -31,7 +34,6 @@ jobs:
           echo "{\"datetime\": \"$(date)\"}" > reports/effort_distribution.json
 
       - name: Compile PDF
-        uses: typst-community/setup-typst@v4
         run: |
           typst compile reports/effort_distribution.typ
 

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -22,7 +22,9 @@ jobs:
         uses: typst-community/setup-typst@v4
 
       - name: Compute distribution
-        run: uvx git-fame --excl "uv.lock,assignment_spec.pdf,LICENSE.md,README.md,pyproject.toml,.gitignore,.pre-commit-config.yaml" --no-regex -M -C --format csv > reports/git_fame_output.csv
+        run: |
+          uvx git-fame
+          uvx git-fame --excl "uv.lock,assignment_spec.pdf,LICENSE.md,README.md,pyproject.toml,.gitignore,.pre-commit-config.yaml" --no-regex -M -C --format csv > reports/git_fame_output.csv
 
       - name: Split into detailed and summary
         run: |

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - report/effort-distribution
 
 jobs:
   generate-distribution:

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -45,7 +45,5 @@ jobs:
       - name: Export PDF
         uses: actions/upload-artifact@v4
         with:
-          name: effort_distribution.pdf
+          name: effort_distribution
           path: reports/effort_distribution.pdf
-          if-no-files-found: error
-          retention-days: 7

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -45,5 +45,7 @@ jobs:
       - name: Export PDF
         uses: actions/upload-artifact@v4
         with:
-          name: git_fame_results
+          name: effort_distribution.pdf
           path: reports/effort_distribution.pdf
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Record datetime
         run: |
-          echo "{\"datetime\": \"$(date)\"}" > reports/effort_distribution.json
+          echo "{\"datetime\": \"$(TZ=CET date)\"}" > reports/effort_distribution.json
 
       - name: Compile PDF
         run: |

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -1,0 +1,42 @@
+name: Effort distribution
+
+on:
+  push:
+    branches:
+      - main
+      - report/effort-distribution
+
+jobs:
+  generate-distribution:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.0"
+      
+      - name: Compute distribution
+        run: uvx git-fame --excl "uv.lock,assignment_spec.pdf,LICENSE.md,README.md,pyproject.toml,.gitignore,.pre-commit-config.yaml" --no-regex -M -C --format csv > reports/git_fame_output.csv
+
+      - name: Split into detailed and summary
+        run: |
+          head -n $(( $(wc -l reports/git_fame_output.csv | awk '{print $1}') - 3 )) reports/git_fame_output.csv > reports/git_fame_detailed.csv
+          tail -n 2 reports/git_fame_output.csv > reports/git_fame_summary.csv
+
+      - name: Record datetime
+        run: |
+          echo "{\"datetime\": \"$(date)\"}" > reports/effort_distribution.json
+
+      - name: Compile PDF
+        uses: typst-community/setup-typst@v4
+        run: |
+          typst compile reports/effort_distribution.typ
+
+      - name: Export PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: git_fame_results
+          path: reports/effort_distribution.pdf

--- a/reports/effort_distribution.typ
+++ b/reports/effort_distribution.typ
@@ -1,0 +1,42 @@
+= Team effort distribution report
+
+#show link: set text(fill: blue)
+
+*Assignment number:* 1
+
+*Assignment team number:* 12
+
+*GitHub URL:* #link("https://github.com/MarcellSzegedi/ScientificComputingAssignment_I")
+
+At the start of the assignment, we met to discuss the theory underlying the core of the assignment. Once 
+we had developed a shared understanding of the content, and decided on a rough approach for each section,
+we divided the work. Zainab and Henry primarily worked on the vibrating string and time-dependent diffusion
+questions, while Marcell focused on the time-independent diffusion problems. 
+
+While much of the code was completed individually, we ensured that everyone was kept up-to-date through 
+regular meetings and pull requests. At times, we practiced peer-programming, working in small groups on
+a single laptop. We all contributed equally to the report.
+
+
+= Git Fame distribution of the repository
+Date and time: #json("effort_distribution.json").datetime
+
+Output from Git Fame:
+
+#let git_fame_summary = csv("git_fame_summary.csv")
+#let git_fame_details = csv("git_fame_detailed.csv", )
+
+#show table.cell.where(y: 0): strong
+//#figure(
+#table(
+		columns: 4,
+		..git_fame_summary.flatten(),
+	)
+//)
+
+//#figure(
+#table(
+		columns: 7,
+		..git_fame_details.flatten(),
+	)
+//)


### PR DESCRIPTION
Implements a small GitHub action which produces the effort distribution document any time we push to main. The template is a Typst file, located at `reports/effort_distribution.typ`. 

To download the most recent effort distribution PDF, go to the "Actions" tab on Github, and click the most recent "Effort distribution" job which was run on the main branch. The PDF should be available for download under assets.